### PR TITLE
Add Cloud Function and Terraform setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# backlog-webhook-to-cloudrun-test
+# Backlog Webhook to Firestore via Cloud Functions
+
+This repository contains an example setup to receive Backlog webhooks with a Google Cloud Function and store the payload in Firestore. The infrastructure is provisioned using Terraform.
+
+## Structure
+
+- `function/` – Python source code for the Cloud Function.
+- `terraform/` – Terraform configuration to create the Cloud Function, Firestore database, service account and other required resources.
+
+## Deployment
+
+1. Install [Terraform](https://www.terraform.io/) and authenticate with Google Cloud.
+2. Initialize Terraform and apply the configuration:
+
+```bash
+cd terraform
+terraform init
+terraform apply -var="project=<YOUR_GCP_PROJECT>"
+```
+
+The function URL will be printed in the outputs after apply.
+
+Backlog can be configured to POST webhooks to this URL. Each payload will be stored in the Firestore collection defined by `FIRESTORE_COLLECTION` (defaults to `backlog_webhooks`).

--- a/function/main.py
+++ b/function/main.py
@@ -1,0 +1,17 @@
+import os
+from google.cloud import firestore
+
+collection = os.environ.get("FIRESTORE_COLLECTION", "backlog_webhooks")
+
+db = firestore.Client()
+
+def webhook_handler(request):
+    if request.method != "POST":
+        return ("Method Not Allowed", 405)
+
+    data = request.get_json(silent=True)
+    if data is None:
+        return ("Bad Request: no JSON payload", 400)
+
+    db.collection(collection).add({"payload": data})
+    return ("OK", 200)

--- a/function/requirements.txt
+++ b/function/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-firestore>=2.5.0

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,87 @@
+terraform {
+  required_version = ">= 1.2"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+}
+
+# Enable required services
+resource "google_project_service" "cloudfunctions" {
+  service = "cloudfunctions.googleapis.com"
+}
+
+resource "google_project_service" "firestore" {
+  service = "firestore.googleapis.com"
+}
+
+resource "google_project_service" "cloudbuild" {
+  service = "cloudbuild.googleapis.com"
+}
+
+# Service account for Cloud Function
+resource "google_service_account" "function_sa" {
+  account_id   = "function-sa"
+  display_name = "Cloud Function SA"
+}
+
+resource "google_project_iam_member" "firestore_access" {
+  role   = "roles/datastore.user"
+  member = "serviceAccount:${google_service_account.function_sa.email}"
+}
+
+# Storage bucket for function source
+resource "google_storage_bucket" "function_bucket" {
+  name          = "${var.project}-function-source"
+  location      = var.region
+  force_destroy = true
+}
+
+data "archive_file" "function_zip" {
+  type        = "zip"
+  source_dir  = "../function"
+  output_path = "${path.module}/function.zip"
+}
+
+resource "google_storage_bucket_object" "function_archive" {
+  name   = "function-${data.archive_file.function_zip.output_md5}.zip"
+  bucket = google_storage_bucket.function_bucket.name
+  source = data.archive_file.function_zip.output_path
+}
+
+resource "google_cloudfunctions_function" "function" {
+  name        = var.function_name
+  runtime     = "python39"
+  entry_point = "webhook_handler"
+  region      = var.region
+
+  source_archive_bucket = google_storage_bucket.function_bucket.name
+  source_archive_object = google_storage_bucket_object.function_archive.name
+  service_account_email = google_service_account.function_sa.email
+
+  trigger_http = true
+
+  environment_variables = {
+    FIRESTORE_COLLECTION = var.firestore_collection
+  }
+}
+
+resource "google_app_engine_application" "app" {
+  project     = var.project
+  location_id = var.region
+}
+
+resource "google_firestore_database" "default" {
+  name        = "(default)"
+  project     = var.project
+  location_id = var.region
+  type        = "FIRESTORE_NATIVE"
+  depends_on  = [google_app_engine_application.app]
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "function_url" {
+  value = google_cloudfunctions_function.function.https_trigger_url
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,22 @@
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "function_name" {
+  description = "Name of the Cloud Function"
+  type        = string
+  default     = "backlog-webhook-handler"
+}
+
+variable "firestore_collection" {
+  description = "Firestore collection name"
+  type        = string
+  default     = "backlog_webhooks"
+}


### PR DESCRIPTION
## Summary
- add Python Cloud Function handler
- create Terraform modules to deploy Cloud Function and Firestore
- document deployment steps

## Testing
- `terraform fmt -recursive`
- `terraform validate` *(fails: missing provider due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687ae533e6888328ab9a8accc286ac4c