### PR TITLE
Create Firestore DB by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Terraform artifacts
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup
+terraform/function.zip
+terraform.tfstate
+
+# Python cache
+**/__pycache__/
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# backlog-webhook-to-cloudrun-test
+# Cloud Functions (第2世代) で Backlog の Webhook を Firestore に保存する例
+
+このリポジトリは、Backlog から送られる Webhook を Google Cloud Functions **第2世代** (Python 3.13) で受け取り、Firestore に保存するサンプルです。Firestore が Datastore モードの場合は自動的に Datastore API に切り替えて保存します。インフラは Terraform で構築します。
+
+## 構成
+
+- `function/` – Cloud Function の Python ソースコード
+- `terraform/` – Cloud Function (第2世代) や Firestore、サービスアカウントなどを作成する Terraform 設定
+
+## デプロイ手順
+
+1. [Terraform](https://www.terraform.io/) をインストールし、Google Cloud に認証します。
+2. Terraform を初期化して適用します。
+
+```bash
+cd terraform
+terraform init
+terraform apply -var="project=<YOUR_GCP_PROJECT>"
+```
+
+デフォルトのリージョンは `asia-northeast1` です。別のリージョンを使う場合は `-var="region=<REGION>"` を指定してください。適用後、関数の URL が出力されます。
+
+`gcf-artifacts` へのアクセス権がなく 403 エラーになる場合は、Cloud Functions のサービス エージェントに `roles/artifactregistry.reader` 権限を付与してください。Terraform では関数作成後に自動的にこの権限を付与します。
+
+Terraform はデフォルトで Firestore のデータベース (ネイティブモード) を作成します。既にデータベースがあるプロジェクトでは `manage_firestore_database` 変数を `false` にして作成をスキップしてください。そうしないと `Database already exists` エラーになります。
+
+`log_level` 変数で関数のログレベルを変更できます。`DEBUG` に設定するとリクエスト内容や Firestore のエラーを詳細に記録し、`500` エラーの原因を調査しやすくなります。
+
+プロジェクトが **Firestore の Datastore モード** を使用している場合、関数は自動的に Datastore API に切り替えます。ログには次のように表示されます。
+
+```
+Firestore in Datastore mode; using Datastore client
+```
+
+この場合もデータは Datastore に保存されます。
+
+Backlog の Webhook URL としてこの関数のエンドポイントを指定すると、受け取った JSON ペイロードが `FIRESTORE_COLLECTION` (デフォルトは `backlog_webhooks`) に保存されます。
+
+`LOG_LEVEL` を `DEBUG` にすると、予期しない `500` エラーの原因を追跡するための詳細なログが出力されます。Terraform の `log_level` 変数から設定できます。
+
+Terraform の状態ファイルや `function.zip` などのビルド成果物は `.gitignore` で除外しています。不要なファイルがリポジトリに含まれないよう確認してください。

--- a/function/main.py
+++ b/function/main.py
@@ -1,0 +1,43 @@
+import os
+import logging
+from google.cloud import firestore
+from google.cloud import datastore
+from google.api_core import exceptions
+
+collection = os.environ.get("FIRESTORE_COLLECTION", "backlog_webhooks")
+log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
+
+db = firestore.Client()
+ds = datastore.Client()
+
+def webhook_handler(request):
+    logging.debug("Received %s request", request.method)
+    if request.method != "POST":
+        logging.warning("Invalid method: %s", request.method)
+        return ("Method Not Allowed", 405)
+
+    data = request.get_json(silent=True)
+    if data is None:
+        logging.warning("No JSON payload")
+        return ("Bad Request: no JSON payload", 400)
+
+    try:
+        doc_ref = db.collection(collection).add({"payload": data})
+        logging.debug("Stored document: %s", doc_ref[1].id)
+    except exceptions.FailedPrecondition:
+        # Firestore is in Datastore mode. Use Datastore client instead.
+        logging.warning("Firestore in Datastore mode; using Datastore client")
+        try:
+            key = ds.key(collection)
+            entity = datastore.Entity(key=key)
+            entity.update({"payload": data})
+            ds.put(entity)
+            logging.debug("Stored Datastore entity: %s", entity.key.id_or_name)
+        except Exception:
+            logging.exception("Failed to store payload in Datastore")
+            return ("Internal Server Error", 500)
+    except Exception:
+        logging.exception("Failed to store payload")
+        return ("Internal Server Error", 500)
+    return ("OK", 200)

--- a/function/requirements.txt
+++ b/function/requirements.txt
@@ -1,0 +1,2 @@
+google-cloud-firestore>=2.5.0
+google-cloud-datastore>=2.0.0

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,119 @@
+terraform {
+  required_version = ">= 1.2"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+}
+
+# Lookup project info (number needed for service agent email)
+data "google_project" "current" {
+  project_id = var.project
+}
+
+# Enable required services
+resource "google_project_service" "cloudfunctions" {
+  service = "cloudfunctions.googleapis.com"
+}
+
+resource "google_project_service" "firestore" {
+  service = "firestore.googleapis.com"
+}
+
+resource "google_project_service" "cloudbuild" {
+  service = "cloudbuild.googleapis.com"
+}
+
+# Grant Artifact Registry read access to the Cloud Functions service agent
+resource "google_project_iam_member" "cloudfunctions_artifact_registry" {
+  project    = var.project
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:service-${data.google_project.current.number}@gcf-admin-robot.iam.gserviceaccount.com"
+  depends_on = [google_project_service.cloudfunctions]
+}
+
+# Service account for Cloud Function
+resource "google_service_account" "function_sa" {
+  account_id   = "function-sa"
+  display_name = "Cloud Function SA"
+}
+
+resource "google_project_iam_member" "firestore_access" {
+  project = var.project
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.function_sa.email}"
+}
+
+# Storage bucket for function source
+resource "google_storage_bucket" "function_bucket" {
+  name          = "${var.project}-function-source"
+  location      = var.region
+  force_destroy = true
+}
+
+data "archive_file" "function_zip" {
+  type        = "zip"
+  source_dir  = "../function"
+  output_path = "${path.module}/function.zip"
+}
+
+resource "google_storage_bucket_object" "function_archive" {
+  name   = "function-${data.archive_file.function_zip.output_md5}.zip"
+  bucket = google_storage_bucket.function_bucket.name
+  source = data.archive_file.function_zip.output_path
+}
+
+resource "google_cloudfunctions2_function" "function" {
+  name     = var.function_name
+  location = var.region
+
+  build_config {
+    runtime     = "python313"
+    entry_point = "webhook_handler"
+
+    source {
+      storage_source {
+        bucket = google_storage_bucket.function_bucket.name
+        object = google_storage_bucket_object.function_archive.name
+      }
+    }
+  }
+
+  service_config {
+    service_account_email = google_service_account.function_sa.email
+    environment_variables = {
+      FIRESTORE_COLLECTION = var.firestore_collection
+      LOG_LEVEL            = var.log_level
+    }
+  }
+}
+
+resource "google_cloud_run_service_iam_member" "invoker" {
+  project    = var.project
+  location   = var.region
+  service    = google_cloudfunctions2_function.function.name
+  role       = "roles/run.invoker"
+  member     = "allUsers"
+  depends_on = [google_cloudfunctions2_function.function]
+}
+
+resource "google_app_engine_application" "app" {
+  project     = var.project
+  location_id = var.region
+}
+
+resource "google_firestore_database" "default" {
+  count       = var.manage_firestore_database ? 1 : 0
+  name        = "(default)"
+  project     = var.project
+  location_id = var.region
+  type        = "FIRESTORE_NATIVE"
+  depends_on  = [google_app_engine_application.app]
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "function_url" {
+  value = google_cloudfunctions2_function.function.service_config[0].uri
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-northeast1"
+}
+
+variable "function_name" {
+  description = "Name of the Cloud Function"
+  type        = string
+  default     = "backlog-webhook-handler"
+}
+
+variable "firestore_collection" {
+  description = "Firestore collection name"
+  type        = string
+  default     = "backlog_webhooks"
+}
+
+variable "manage_firestore_database" {
+  description = "Whether Terraform should create the Firestore database"
+  type        = bool
+  default     = true
+}
+
+variable "log_level" {
+  description = "Logging level for the Cloud Function"
+  type        = string
+  default     = "INFO"
+}


### PR DESCRIPTION
## Summary
- create a Firestore Native database unless disabled
- document the new default in the Japanese README

## Testing
- ✅ `terraform fmt -recursive`
- ❌ `terraform init -backend=false` (failed to query provider packages)
- ❌ `terraform validate` (missing required provider)


------
https://chatgpt.com/codex/tasks/task_e_687ae533e6888328ab9a8accc286ac4c