### PR TITLE
Add project and issue keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Terraform artifacts
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup
+terraform/function.zip
+terraform.tfstate
+terraform_*.zip
+
+# Python cache
+**/__pycache__/
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# backlog-webhook-to-cloudrun-test
+# Cloud Functions (第2世代) で Backlog Webhook を Firestore に保存する例
+
+このリポジトリは、Backlog から送られる Webhook を Google Cloud Functions **第2世代** (Python 3.13) で受け取り、Firestore ネイティブモード に保存するサンプルです。オプションで Pub/Sub を利用して非同期処理に切り替えることもできます。インフラは Terraform で構築します。
+
+## 構成
+
+- `function/` – Cloud Functions の Python コード
+- `terraform/` – GCP リソースを作成する Terraform 設定
+
+## デプロイ手順
+
+1. [Terraform](https://www.terraform.io/) をインストールし、Google Cloud に認証します。
+2. Terraform を初期化して適用します。
+
+```bash
+cd terraform
+terraform init
+terraform apply -var="project=<YOUR_GCP_PROJECT>"
+```
+
+デフォルトのリージョンは `asia-northeast1` です。別のリージョンを使う場合は `-var="region=<REGION>"` を指定してください。`use_pubsub=true` を渡すと Pub/Sub 経由で処理されます。
+Firestore データベースを自動作成したい場合は `-var="manage_firestore_database=true"` を、すでに存在する場合は `false` を指定してください。
+Firestore のデータベース名は `firestore_database_id` 変数で変更でき、Cloud Function には `FIRESTORE_DATABASE` 環境変数として渡されます。
+
+関数の URL が出力されるので、Backlog の Webhook 先として設定してください。`log_level` を `DEBUG` にすると詳細なログが得られます。
+
+## 処理概要
+
+Webhook 受信関数は JSON ペイロードを受け取り、`USE_PUBSUB` 環境変数が `true` の場合は Pub/Sub トピックへメッセージを publish します。`false` の場合はそのまま Firestore へ保存します。Pub/Sub を使用する場合は、`pubsub_handler` 関数がメッセージを購読して Firestore への書き込みを行います。
+イベントタイプは [Backlog API の "最近の更新情報" ドキュメント](https://developer.nulab.com/ja/docs/backlog/api/2/get-recent-updates/) を参照しています。
+主な数値は次の通りです。
+
+| 値  | 内容                       |
+|-----|----------------------------|
+| 1   | 課題の追加                 |
+| 2   | 課題の更新                 |
+| 3   | 課題にコメント             |
+| 4   | 課題の削除                 |
+| 14  | 課題をまとめて更新         |
+| 17  | コメントにお知らせを追加   |
+
+Firestore では次の 3 つのコレクションを利用します。
+
+- `backlog-issue`
+- `backlog-comment`
+- `backlog-comment-notif`
+
+イベントタイプ (課題追加・更新・コメント・削除など) に応じてそれぞれのコレクションへデータを追加・更新・削除します。各コレクションでは主なフィールドを抜き出して保存しており、例えば `backlog-issue` では課題 ID やステータス、担当者に加えて `projectKey` と `issueKey` も文字列として保存します。`backlog-comment` ではコメント ID・発言者・本文などを格納します。
+
+Terraform ではデフォルトで必要な API を有効化し、Cloud Function 用のサービスアカウントと Pub/Sub トピック (必要な場合) を作成します。Artifact Registry へのアクセス権も自動で付与されます。
+
+`.gitignore` には Terraform の状態ファイルや `function.zip` などの生成物を除外する設定が含まれています。

--- a/function/main.py
+++ b/function/main.py
@@ -1,0 +1,161 @@
+import os
+import json
+import base64
+import logging
+from google.cloud import firestore
+from google.cloud import pubsub_v1
+import google.auth
+
+# Logging setup
+log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
+
+USE_PUBSUB = os.environ.get("USE_PUBSUB", "false").lower() == "true"
+PUBSUB_TOPIC = os.environ.get("PUBSUB_TOPIC", "backlog-webhook")
+try:
+    _, default_project = google.auth.default()
+except Exception:
+    default_project = None
+PROJECT_ID = (
+    os.environ.get("PROJECT_ID")
+    or os.environ.get("GOOGLE_CLOUD_PROJECT")
+    or os.environ.get("GCP_PROJECT")
+    or default_project
+)
+FIRESTORE_DATABASE = os.environ.get("FIRESTORE_DATABASE", "(default)")
+
+# Firestore client
+db = firestore.Client(project=PROJECT_ID, database=FIRESTORE_DATABASE)
+
+# Pub/Sub client only when needed
+publisher = pubsub_v1.PublisherClient() if USE_PUBSUB else None
+if USE_PUBSUB:
+    topic_path = publisher.topic_path(PROJECT_ID, PUBSUB_TOPIC)
+else:
+    topic_path = None
+
+def webhook_handler(request):
+    """HTTP entry point for Backlog webhook."""
+    logging.debug("Received %s request", request.method)
+    if request.method != "POST":
+        logging.warning("Invalid method: %s", request.method)
+        return ("Method Not Allowed", 405)
+
+    data = request.get_json(silent=True)
+    if data is None:
+        logging.warning("No JSON payload")
+        return ("Bad Request: no JSON payload", 400)
+
+    if USE_PUBSUB:
+        try:
+            payload = json.dumps(data).encode()
+            future = publisher.publish(topic_path, payload)
+            future.result()
+            logging.info("Published message to Pub/Sub")
+            return ("OK", 200)
+        except Exception as e:
+            logging.exception("Failed to publish message: %s", e)
+            return ("Internal Server Error", 500)
+    else:
+        try:
+            process_event(data)
+            return ("OK", 200)
+        except Exception as e:
+            logging.exception("Failed to process event: %s", e)
+            return ("Internal Server Error", 500)
+
+def pubsub_handler(event, context):
+    """Triggered from Pub/Sub when USE_PUBSUB is true."""
+    try:
+        payload = base64.b64decode(event["data"]).decode()
+        data = json.loads(payload)
+        process_event(data)
+    except Exception as e:
+        logging.exception("Failed to handle Pub/Sub message: %s", e)
+        raise
+
+def process_event(data):
+    """Process a Backlog webhook payload."""
+    event_type = data.get("type")
+    content = data.get("content", {})
+    logging.debug("Processing event %s", event_type)
+
+    if str(event_type) in ("1", "2", "14"):
+        store_issue(data, content)
+    elif str(event_type) == "4":
+        delete_issue(content)
+    elif str(event_type) == "3":
+        store_comment(data, content)
+    elif str(event_type) == "17":
+        store_comment_notif(data, content)
+    else:
+        logging.warning("Unknown event type: %s", event_type)
+
+def store_issue(root, issue):
+    """Save issue fields to Firestore."""
+    issue_id = str(issue.get("id"))
+    doc = {
+        "issue_id": issue_id,
+        "project_id": root.get("project", {}).get("id"),
+        "project_key": root.get("project", {}).get("projectKey"),
+        "issue_key": f"{root.get('project', {}).get('projectKey')}-{issue.get('key_id')}" if issue.get("key_id") else None,
+        "title": issue.get("summary"),
+        "status_id": issue.get("status", {}).get("id"),
+        "status": issue.get("status", {}).get("name"),
+        "assignee_id": (issue.get("assignee") or {}).get("id"),
+        "assignee_name": (issue.get("assignee") or {}).get("name"),
+        "issue_type_id": issue.get("issueType", {}).get("id"),
+        "issue_type_name": issue.get("issueType", {}).get("name"),
+        "priority_id": issue.get("priority", {}).get("id"),
+        "priority_name": issue.get("priority", {}).get("name"),
+        "description": issue.get("description"),
+        "created_at": root.get("created"),
+    }
+    db.collection("backlog-issue").document(issue_id).set(doc)
+    logging.info("Stored/updated issue %s", issue_id)
+
+def delete_issue(issue):
+    issue_id = str(issue.get("issue_id") or issue.get("id"))
+    db.collection("backlog-issue").document(issue_id).delete()
+    logging.info("Deleted issue %s", issue_id)
+
+def store_comment(root, content):
+    """Save issue comment details."""
+    comment = content.get("comment", {})
+    comment_id = str(comment.get("id"))
+    issue_key = None
+    if content.get("key_id") is not None:
+        issue_key = f"{root.get('project', {}).get('projectKey')}-{content.get('key_id')}"
+    doc = {
+        "comment_id": comment_id,
+        "issue_key": issue_key,
+        "author_id": root.get("createdUser", {}).get("id"),
+        "author_name": root.get("createdUser", {}).get("name"),
+        "content": comment.get("content"),
+        "created_at": root.get("created"),
+    }
+    db.collection("backlog-comment").document(comment_id).set(doc)
+    logging.info("Stored/updated comment %s", comment_id)
+
+def delete_comment(comment):
+    comment_id = str(comment.get("key") or comment.get("comment_id") or comment.get("id"))
+    db.collection("backlog-comment").document(comment_id).delete()
+    logging.info("Deleted comment %s", comment_id)
+
+def store_comment_notif(root, content):
+    """Save notification entries."""
+    comment_id = (content.get("comment") or {}).get("id")
+    for notif in root.get("notifications", []):
+        notif_id = str(notif.get("id"))
+        doc = {
+            "comment_id": comment_id,
+            "notification_id": notif_id,
+            "user_id": notif.get("user", {}).get("id"),
+            "user_name": notif.get("user", {}).get("name"),
+            "already_read": notif.get("alreadyRead"),
+            "resource_already_read": notif.get("resourceAlreadyRead"),
+            "reason": notif.get("reason"),
+            "notified_at": root.get("created"),
+        }
+        db.collection("backlog-comment-notif").document(notif_id).set(doc)
+        logging.info("Stored/updated notification %s", notif_id)

--- a/function/requirements.txt
+++ b/function/requirements.txt
@@ -1,0 +1,2 @@
+google-cloud-firestore>=2.0.0
+google-cloud-pubsub>=2.17.0

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,172 @@
+terraform {
+  required_version = ">= 1.2"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+}
+
+# Lookup project info (number needed for service agent email)
+data "google_project" "current" {
+  project_id = var.project
+}
+
+# Enable required services
+resource "google_project_service" "cloudfunctions" {
+  service = "cloudfunctions.googleapis.com"
+}
+
+resource "google_project_service" "firestore" {
+  service = "firestore.googleapis.com"
+}
+
+resource "google_project_service" "cloudbuild" {
+  service = "cloudbuild.googleapis.com"
+}
+
+# Grant Artifact Registry read access to the Cloud Functions service agent
+resource "google_project_iam_member" "cloudfunctions_artifact_registry" {
+  project    = var.project
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:service-${data.google_project.current.number}@gcf-admin-robot.iam.gserviceaccount.com"
+  depends_on = [google_project_service.cloudfunctions]
+}
+
+# Service account for Cloud Function
+resource "google_service_account" "function_sa" {
+  account_id   = "function-sa"
+  display_name = "Cloud Function SA"
+}
+
+resource "google_project_iam_member" "firestore_access" {
+  project = var.project
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.function_sa.email}"
+}
+
+# Storage bucket for function source
+resource "google_storage_bucket" "function_bucket" {
+  name          = "${var.project}-function-source"
+  location      = var.region
+  force_destroy = true
+}
+
+resource "google_pubsub_topic" "webhook" {
+  count   = var.use_pubsub ? 1 : 0
+  name    = var.pubsub_topic
+  project = var.project
+}
+
+resource "google_project_iam_member" "pubsub_publisher" {
+  count   = var.use_pubsub ? 1 : 0
+  project = var.project
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${google_service_account.function_sa.email}"
+}
+
+resource "google_project_iam_member" "pubsub_subscriber" {
+  count   = var.use_pubsub ? 1 : 0
+  project = var.project
+  role    = "roles/pubsub.subscriber"
+  member  = "serviceAccount:${google_service_account.function_sa.email}"
+}
+
+data "archive_file" "function_zip" {
+  type        = "zip"
+  source_dir  = "../function"
+  output_path = "${path.module}/function.zip"
+}
+
+resource "google_storage_bucket_object" "function_archive" {
+  name   = "function-${data.archive_file.function_zip.output_md5}.zip"
+  bucket = google_storage_bucket.function_bucket.name
+  source = data.archive_file.function_zip.output_path
+}
+
+resource "google_cloudfunctions2_function" "function" {
+  name     = var.function_name
+  location = var.region
+
+  build_config {
+    runtime     = "python313"
+    entry_point = "webhook_handler"
+
+    source {
+      storage_source {
+        bucket = google_storage_bucket.function_bucket.name
+        object = google_storage_bucket_object.function_archive.name
+      }
+    }
+  }
+
+  service_config {
+    service_account_email = google_service_account.function_sa.email
+    environment_variables = {
+      LOG_LEVEL          = var.log_level
+      USE_PUBSUB         = tostring(var.use_pubsub)
+      PUBSUB_TOPIC       = var.pubsub_topic
+      FIRESTORE_DATABASE = var.firestore_database_id
+      PROJECT_ID         = var.project
+    }
+  }
+}
+
+resource "google_cloudfunctions2_function" "processor" {
+  count    = var.use_pubsub ? 1 : 0
+  name     = "${var.function_name}-processor"
+  location = var.region
+
+  build_config {
+    runtime     = "python313"
+    entry_point = "pubsub_handler"
+
+    source {
+      storage_source {
+        bucket = google_storage_bucket.function_bucket.name
+        object = google_storage_bucket_object.function_archive.name
+      }
+    }
+  }
+
+  service_config {
+    service_account_email = google_service_account.function_sa.email
+    environment_variables = {
+      LOG_LEVEL          = var.log_level
+      USE_PUBSUB         = tostring(var.use_pubsub)
+      PUBSUB_TOPIC       = var.pubsub_topic
+      FIRESTORE_DATABASE = var.firestore_database_id
+      PROJECT_ID         = var.project
+    }
+  }
+
+  event_trigger {
+    trigger_region = var.region
+    event_type     = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic   = google_pubsub_topic.webhook[0].id
+  }
+}
+
+resource "google_cloud_run_service_iam_member" "invoker" {
+  project    = var.project
+  location   = var.region
+  service    = google_cloudfunctions2_function.function.name
+  role       = "roles/run.invoker"
+  member     = "allUsers"
+  depends_on = [google_cloudfunctions2_function.function]
+}
+
+resource "google_firestore_database" "default" {
+  count       = var.manage_firestore_database ? 1 : 0
+  project     = var.project
+  name        = var.firestore_database_id
+  location_id = var.region
+  type        = "FIRESTORE_NATIVE"
+  depends_on  = [google_project_service.firestore]
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "function_url" {
+  value = google_cloudfunctions2_function.function.service_config[0].uri
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,46 @@
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-northeast1"
+}
+
+variable "function_name" {
+  description = "HTTP Cloud Function name"
+  type        = string
+  default     = "backlog-webhook-handler"
+}
+
+variable "use_pubsub" {
+  description = "Publish webhook payloads to Pub/Sub"
+  type        = bool
+  default     = false
+}
+
+variable "pubsub_topic" {
+  description = "Pub/Sub topic name when use_pubsub is true"
+  type        = string
+  default     = "backlog-webhook"
+}
+
+variable "log_level" {
+  description = "Logging level for the Cloud Function"
+  type        = string
+  default     = "INFO"
+}
+
+variable "manage_firestore_database" {
+  description = "Create Firestore database if true"
+  type        = bool
+  default     = true
+}
+
+variable "firestore_database_id" {
+  description = "Firestore database ID"
+  type        = string
+  default     = "backlog-db"
+}


### PR DESCRIPTION
## Summary
- store projectKey and issueKey strings when saving issues and comments
- document that projectKey and issueKey are saved as strings

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_687ae533e6888328ab9a8accc286ac4c