### PR TITLE
Handle bulk issue update events

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Webhook 受信関数は JSON ペイロードを受け取り、`USE_PUBSUB` 環�
 | 14  | 課題をまとめて更新         |
 | 17  | コメントにお知らせを追加   |
 
+イベントタイプ14では `content.link` に複数の課題が含まれます。`changes` の内容を
+各課題へ適用し、`backlog-issue` コレクションの既存ドキュメントを `merge=True` で
+更新します。
+
 Firestore では次の 3 つのコレクションを利用します。
 
 - `backlog-issue`


### PR DESCRIPTION
## Summary
- recognize backlog bulk update (event type 14)
- add `store_bulk_update` helper to apply changes across issues
- document how bulk updates are saved

## Testing
- `python3 -m py_compile function/main.py`

------
https://chatgpt.com/codex/tasks/task_e_687de314409c83289c60ddf98f49367a